### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Markdown Downloader is a powerful MCP (Model Context Protocol) server that allows you to download webpages as markdown files with ease. Leveraging the r.jina.ai service, this tool provides a seamless way to convert web content into markdown format.
 
+<a href="https://glama.ai/mcp/servers/jrki7zltg7">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/jrki7zltg7/badge" alt="Markdown Downloader MCP server" />
+</a>
+
 ## Features
 
 - 🌐 Download webpages as markdown using r.jina.ai
@@ -34,6 +38,7 @@ Markdown Downloader is a powerful MCP (Model Context Protocol) server that allow
    ```bash
    npm run build
    ```
+
 ## Manually Add Server to Cline/Roo-Cline MCP Settings file  
 
 ```


### PR DESCRIPTION
This PR adds a badge for the [Markdown Downloader](https://glama.ai/mcp/servers/jrki7zltg7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jrki7zltg7">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/jrki7zltg7/badge" alt="Markdown Downloader MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.